### PR TITLE
cli: use real Option<bool> in TOML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status](https://travis-ci.org/overdrop/overdrop-sebool.svg?branch=master)](https://travis-ci.org/overdrop/overdrop-sebool)
 
-A small Rust binary to apply SELinux booleans runtime values.
+A small Rust binary to manage SELinux booleans at runtime.
 
 It allows to tweak SELinux boolean values and persist changes across
-reboots, via plaintext configuration files. It is targeted toward
+reboots, via TOML configuration files. It is targeted toward
 early-boot configuration of an immutable OS, and aims at [decoupling
 configuration concerns](https://github.com/projectatomic/rpm-ostree/issues/27)
 regarding vendor-defaults, user-configuration and internal/runtime state.
@@ -23,7 +23,7 @@ This binary can be directly used as a systemd service to setup
 SELinux booleans at early-boot. A live-action demo of that is in
 the following asciinema recording:
 
-[![asciicast](https://asciinema.org/a/KNOHnpHlbULVQKnSrifcWqaJV.png)](https://asciinema.org/a/KNOHnpHlbULVQKnSrifcWqaJV)
+[![asciicast](https://asciinema.org/a/200268.png)](https://asciinema.org/a/200268)
 
 # Disclaimer
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,14 +50,9 @@ pub(crate) fn merge_cfg(
 pub(crate) fn accumulate_snippet(cur: SeboolCfg, snip: SeboolCfgSnippet) -> SeboolCfg {
     let mut res = cur;
     for (k, v) in snip.bools {
-        // This mimics an `Option<bool>`, not supported by TOML syntax.
-        if v == "" {
-            res.bools.remove(&k);
-            continue;
-        }
-
-        if let Ok(b) = v.parse() {
-            res.bools.insert(k, b);
+        match v.value {
+            None => res.bools.remove(&k),
+            Some(b) => res.bools.insert(k, b),
         };
     }
     res
@@ -83,5 +78,10 @@ pub(crate) struct SeboolCfg {
 #[derive(Deserialize)]
 pub(crate) struct SeboolCfgSnippet {
     #[serde(rename = "sebool")]
-    bools: collections::BTreeMap<String, String>,
+    bools: collections::BTreeMap<String, SeboolValue>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct SeboolValue {
+    value: Option<bool>,
 }


### PR DESCRIPTION
This updates the configuration format to use a real optional-bool value
instead of strings.